### PR TITLE
Added possibility to use Telegram

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -1,9 +1,19 @@
 {
+  /* Choose 'telegram' or 'pushbullet' according to your favorite way of get informed */
+  "informBy": "",
+
   "packtpub": {
     "email": "",
     "password": ""
   },
+  
   "pushbullet": {
     "apiKey": ""
+  },
+
+  /* to use telegram, you have to create a bot first. See: https://core.telegram.org/bots#3-how-do-i-create-a-bot */
+  "telegram": {
+    "botToken" : "",
+    "receiverId" : ""
   }
 }

--- a/index.js
+++ b/index.js
@@ -45,14 +45,14 @@ request(packtpubFreeEbookUrl, function(error, response, body) {
                 request(freeEbookUrl, function(error, response, body) {
                     if (error) {
                         console.error('claim error', error);
-                        pusher.note('', 'packtpub claim bot error', "Got a error please check this!", function(error, response) {
+                        inform('packtpub claim bot error', "Got a error please check this!", function(error, response) {
                             if (error) {
                                 console.error('pushbullet failure', error);
                             }
                         });
                     }
                     if (!error && response.statusCode == 200) {
-                        pusher.note('', 'packtpub claim bot', "Sir, I've just claimed " + freeEbookTitle + " for you.", function(error, response) {
+                        inform('packtpub claim bot', "Sir, I've just claimed " + freeEbookTitle + " for you.", function(error, response) {
                             if (error) {
                                 console.error('pushbullet failure', error);
                             }
@@ -66,3 +66,25 @@ request(packtpubFreeEbookUrl, function(error, response, body) {
         });
     }
 })
+
+function inform(name, content, handler){
+  if(config.informBy=="telegram"){
+    informTelegram(content, config.telegram.receiverId, config.telegram.botToken);
+  } else if(config.informBy=="pushbullet"){
+    informPusher(name, content, handler);
+  } else {
+    console.log(content);
+  }
+}
+
+function informPusher(name, content, handler){
+  pusher.note('', name, content, handler);
+}
+
+function informTelegram(content, receiver, token) {
+  var TelegramBot = require('node-telegram-bot-api');
+  // just send the message
+  var bot = new TelegramBot(token, {polling: true});
+
+  bot.sendMessage(receiver, content);
+}


### PR DESCRIPTION
Initially, this service sends infos via Pushbullet to an receiver. I added the possibility to use a Telegram bot, which sends infos to a specific receiver, maybe yourself. 

I added a config switch: "informBy" which can hold the values "pushbullet" or "telegram", and if not chosen, to the console.log. My implementation uses a separate inform() function.
